### PR TITLE
Fix: Improve buffer clearing timing to prevent missing audio

### DIFF
--- a/src/services/AudioInterceptor.ts
+++ b/src/services/AudioInterceptor.ts
@@ -319,12 +319,6 @@ export default class AudioInterceptor {
           this.logger.info(
             'Caller translation completed - resuming untranslated audio forwarding',
           );
-          
-          // Clear the input audio buffer to prevent audio accumulation and repetition
-          this.sendMessageToOpenAI(this.#callerOpenAISocket!, {
-            type: 'input_audio_buffer.clear'
-          });
-          this.logger.info('Cleared caller input audio buffer to prevent repetition');
         }
 
         if (message.type === 'input_audio_buffer.speech_stopped') {
@@ -335,6 +329,13 @@ export default class AudioInterceptor {
             message_id: message.event_id,
             vad_speech_stopped_time: currentTime,
           });
+          
+          // Clear the input audio buffer after speech stops to prevent audio accumulation
+          // This ensures we don't clear mid-speech and lose audio that's still being processed
+          this.sendMessageToOpenAI(this.#callerOpenAISocket!, {
+            type: 'input_audio_buffer.clear'
+          });
+          this.logger.info('Cleared caller input audio buffer after speech stopped');
         }
 
         if (message.type === 'response.audio.delta') {
@@ -384,12 +385,6 @@ export default class AudioInterceptor {
           this.logger.info(
             'Agent translation completed - resuming untranslated audio forwarding',
           );
-          
-          // Clear the input audio buffer to prevent audio accumulation and repetition
-          this.sendMessageToOpenAI(this.#agentOpenAISocket!, {
-            type: 'input_audio_buffer.clear'
-          });
-          this.logger.info('Cleared agent input audio buffer to prevent repetition');
         }
 
         if (message.type === 'input_audio_buffer.speech_stopped') {
@@ -400,6 +395,13 @@ export default class AudioInterceptor {
             message_id: message.event_id,
             vad_speech_stopped_time: currentTime,
           });
+          
+          // Clear the input audio buffer after speech stops to prevent audio accumulation
+          // This ensures we don't clear mid-speech and lose audio that's still being processed
+          this.sendMessageToOpenAI(this.#agentOpenAISocket!, {
+            type: 'input_audio_buffer.clear'
+          });
+          this.logger.info('Cleared agent input audio buffer after speech stopped');
         }
 
         if (message.type === 'response.audio.delta') {


### PR DESCRIPTION
## Problem

After implementing buffer clearing to prevent duplicate translations, users reported that sometimes translations were missing the first part of what was said. This was happening because the buffer was being cleared too aggressively.

## Root Cause

The previous fix cleared the `input_audio_buffer` immediately when `response.done` was received. However, this created a **race condition**:

**Example scenario:**
1. Person says "Hello world" as one continuous phrase
2. "Hello" audio → sent to OpenAI buffer
3. "world" audio → sent to OpenAI buffer (while "Hello" is being processed)
4. OpenAI finishes processing "Hello" → sends `response.done`
5. We immediately clear the buffer → **"world" gets deleted before OpenAI processes it!**
6. Result: Translation only contains "Hello", missing "world"

## Solution

Move the buffer clearing from `response.done` events to `input_audio_buffer.speech_stopped` events. This ensures we only clear the buffer after:

1. ✅ The person has actually stopped speaking (confirmed by VAD)
2. ✅ All audio from that speech segment has been sent to OpenAI
3. ✅ No risk of clearing mid-speech and losing audio

## Changes

- **Removed** `input_audio_buffer.clear` from `response.done`/`response.audio.done` handlers
- **Added** `input_audio_buffer.clear` to `input_audio_buffer.speech_stopped` handlers
- Applied to both caller and agent translation sessions
- Updated logging to reflect the new timing

## Expected Behavior

**Before (problematic):**
1. Person says "Hello world"
2. OpenAI processes "Hello" → clears buffer → loses "world"
3. Translation: "Hello" ❌

**After (fixed):**
1. Person says "Hello world"
2. Speech detection confirms person stopped talking
3. Buffer cleared only after complete speech segment processed
4. Translation: "Hello world" ✅

## Benefits

- ✅ **No missing audio**: Complete speech segments are always processed
- ✅ **No duplicate translations**: Buffer still gets cleared to prevent repetition
- ✅ **No translation interruptions**: Previous `interrupt_response: false` fix remains
- ✅ **Proper timing**: Buffer clearing synchronized with speech detection

This fix ensures that all three issues are resolved:
1. Translations never get cut off
2. No duplicate translations 
3. No missing audio from speech segments