### PR TITLE
Fix audio buffer timing calculation

### DIFF
--- a/src/services/AudioInterceptor.ts
+++ b/src/services/AudioInterceptor.ts
@@ -452,13 +452,24 @@ export default class AudioInterceptor {
     });
   }
 
-  private reportOnSocketTimeToFirstAudioBufferAdd(messages: BufferedMessage[]) {
+  private reportOnSocketTimeToFirstAudioBufferAdd(
+    messages: BufferedMessage[] = [],
+  ) {
+    if (!messages.length) {
+      return 0;
+    }
+
     const filtered = messages.filter(
-      (message) => message.first_audio_buffer_add_time,
+      (message) => message.first_audio_buffer_add_time !== undefined,
     );
+
+    if (filtered.length === 0) {
+      return 0;
+    }
+
     const totalTime = filtered.reduce(
       (acc, { first_audio_buffer_add_time, vad_speech_stopped_time }) =>
-        acc + (first_audio_buffer_add_time - vad_speech_stopped_time),
+        acc + (first_audio_buffer_add_time! - vad_speech_stopped_time),
       0,
     );
 


### PR DESCRIPTION
## Summary
- handle empty audio message lists when computing average delay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840aed5bd5c832694cd428719711ab5